### PR TITLE
fix: preserve held pointer motion

### DIFF
--- a/components/kvm_hid/usb_hid.c
+++ b/components/kvm_hid/usb_hid.c
@@ -754,6 +754,14 @@ static bool merge_mouse(q_msg_t *acc, const q_msg_t *add)
     if (acc_buttons != add_buttons) {
         return false;
     }
+    /* A held-button move is semantic input, not disposable cursor motion. In
+     * particular, drawing and drag-and-drop targets need the intermediate
+     * positions to reconstruct the path. Folding a whole held drag down to its
+     * final position leaves some hosts with only the press and release marks.
+     * The queue is deliberately deep enough to preserve these reports. */
+    if (acc_buttons != 0) {
+        return false;
+    }
     if (acc->type == Q_MOUSE_ABS) {
         /* Only the newest position matters - intermediate ones are not motion
          * the target needs to see. Scroll clicks still accumulate. */


### PR DESCRIPTION
## Summary

Preserve queued pointer motion while a mouse button is held. Previously, `merge_mouse()` coalesced those reports, so a drag could arrive at the target as a press and release with no motion between them.

This is intentionally board-independent and changes only `components/kvm_hid/usb_hid.c`. Idle motion remains coalesced.

## Validation

- Applied to a Waveshare ESP32-P4-WIFI6 test build.
- On a Xiaomi Pad 6S Pro note canvas, a held relative-mouse drag produced a visible continuous stroke through the real USB HID path.

No board definitions, CMake, network, or capture changes are included.