### PR TITLE
feat: support Waveshare ESP32-P4-WIFI6

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -117,6 +117,11 @@ jobs:
           - id: p4-wifi6-devkit
             build_dir: build.wifi6devkit
             sdkconfig_defaults: sdkconfig.defaults;boards/wifi6devkit_p4.defaults
+          # Waveshare ESP32-P4-WIFI6 - no Ethernet; ESP32-C6 SDIO WiFi and a
+          # setup hotspot are the only management link.
+          - id: p4-wifi6
+            build_dir: build.waveshare_wifi6
+            sdkconfig_defaults: sdkconfig.defaults;boards/waveshare_p4_wifi6.defaults
           # The same two Waveshare boards on rev 3.x silicon. Espressif is still
           # ramping that revision up (volume expected around October 2026) and a
           # product code does not tell you which one is in the box, so both have

--- a/boards/README.md
+++ b/boards/README.md
@@ -17,6 +17,26 @@ idf.py -p /dev/ttyACM0 flash
 Config: `sdkconfig.defaults` + `partitions.csv` (32 MB, `storage` and `rescue`
 both 4 MB). Chip target rev <3.0.
 
+## Waveshare ESP32-P4-WIFI6 (chip rev v1.3, 32 MB flash)
+
+The WiFi-only SKU uses its onboard ESP32-C6 over SDIO and opens its own setup
+hotspot on a fresh ESP-KVM install:
+
+```
+idf.py -B build.waveshare_wifi6 \
+  -D SDKCONFIG=build.waveshare_wifi6/sdkconfig \
+  -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;boards/waveshare_p4_wifi6.defaults" \
+  build
+
+idf.py -B build.waveshare_wifi6 -p /dev/ttyACM0 flash
+```
+
+Config deltas: Ethernet disabled, WiFi/esp-hosted enabled on the documented
+Function-EV-compatible SDIO pins, microSD power-gated by GPIO45, and the UART
+console retained for the onboard CH343 bridge. The separate four-pin USB port
+is the target-facing HID connection. The expansion-header layout was checked
+against the physical board.
+
 ## Espressif ESP32-P4 Function EV Board (chip rev v3.2, 16 MB flash)
 
 An overlay on the common defaults, built into a separate directory so it never

--- a/boards/waveshare_p4_wifi6.defaults
+++ b/boards/waveshare_p4_wifi6.defaults
@@ -1,0 +1,37 @@
+# Waveshare ESP32-P4-WIFI6 (SKU 32020, 32 MB flash, 32 MB PSRAM)
+#
+# Deltas from sdkconfig.defaults. Build in a separate directory:
+#   idf.py -B build.waveshare_wifi6 \
+#     -D SDKCONFIG=build.waveshare_wifi6/sdkconfig \
+#     -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;boards/waveshare_p4_wifi6.defaults" \
+#     build
+#
+# Verified against the vendor schematic and a physical board's ROM report:
+#   ESP32-P4 rev 1.3; 32 MB flash; ESP32-C6 over SDIO on 14-19 with reset 54;
+#   microSD CLK/CMD/D0-D3 on 43/44/39/40/41/42 with active-low power on 45;
+#   BOOT on 35; capture I2C on 7/8; no Ethernet PHY.
+
+# 32 MB flash/partitions and pre-v3 silicon are inherited from sdkconfig.defaults.
+
+# This board has no wired link. Its first boot therefore opens the setup hotspot;
+# after provisioning, the console can switch it to WiFi station mode.
+CONFIG_KVM_ETH_ENABLE=n
+CONFIG_KVM_WIFI=y
+CONFIG_ESP_HOSTED_P4_DEV_BOARD_FUNC_BOARD=y
+CONFIG_SLAVE_IDF_TARGET_ESP32C6=y
+CONFIG_ESP_HOSTED_CP_TARGET_ESP32C6=y
+CONFIG_ESP_HOSTED_AUTO_CALL_INIT_BEFORE_APP_MAIN=n
+
+# GPIO45 drives the microSD VDD P-channel MOSFET and is active low (base default).
+CONFIG_KVM_SD_PWR_GPIO=45
+
+# Keep the default UART console: the board's flashing Type-C reaches GPIO37/38
+# through its CH343 bridge. The separate four-pin USB connector is target HID.
+
+# The CSI connector exposes the bridge's I2C bus and two camera control signals,
+# but neither control signal is routed to GPIO23 on this board. The C790 uses its
+# own power-on reset, so do not toggle or reserve an unrelated expansion GPIO.
+CONFIG_KVM_TC358743_RST_GPIO=-1
+
+CONFIG_KVM_UPDATE_URL="https://espkvm.github.io/espkvm/firmware/p4-wifi6/manifest.json"
+CONFIG_KVM_BOARD_WAVESHARE_WIFI6=y

--- a/components/kvm_board/board_header.c
+++ b/components/kvm_board/board_header.c
@@ -11,6 +11,7 @@
  *
  * Sources:
  *   Waveshare ESP32-P4-ETH   https://www.waveshare.com/wiki/ESP32-P4-ETH
+ *   Waveshare ESP32-P4-WIFI6 https://docs.waveshare.com/ESP32-P4-WIFI6
  *   Waveshare PoE            https://www.waveshare.com/wiki/ESP32-P4-WIFI6-POE-ETH
  *   Waveshare ESP32-P4-NANO  https://www.waveshare.com/esp32-p4-nano.htm
  *   ESP32-P4 Function EV     https://docs.espressif.com/projects/esp-dev-kits/
@@ -87,6 +88,36 @@ static const kvm_board_header_t s_headers[] = {
 #define BOARD_NAME "Waveshare ESP32-P4-WIFI6-DEV-KIT"
 #define BOARD_ID_BASE "p4-wifi6-devkit"
 #define BOARD_VERIFIED false
+
+#elif CONFIG_KVM_BOARD_WAVESHARE_WIFI6
+/*
+ * Two rows of twenty down the long edges. Waveshare prints the carried signal
+ * beside each pad instead of numbering the connector, so expose the two rows in
+ * the same top-to-bottom orientation as the board's official pinout image.
+ */
+static const kvm_board_pin_t s_wifi6_left[] = {
+    IO(52), IO(51), PWR("GND"), IO(31), IO(30), IO(29), IO(28),
+    PWR("GND"), IO(50), IO(49), IO(5), IO(4), PWR("GND"), IO(3),
+    IO(2), IO(8), IO(7), PWR("GND"),
+    IO_NOTE(24, "USB DM"), IO_NOTE(25, "USB DP"),
+};
+_Static_assert(sizeof(s_wifi6_left) / sizeof(s_wifi6_left[0]) == 20,
+               "s_wifi6_left: the column must hold exactly 20 pins");
+static const kvm_board_pin_t s_wifi6_right[] = {
+    PWR("VBUS"), PWR("VSYS"), PWR("GND"), PWR("EN"), PWR("3V3"),
+    IO(20), IO(21), PWR("GND"), IO(22), IO(23), PWR("RUN"), IO(26),
+    PWR("GND"), IO(27), IO(32), IO(33), IO(46), PWR("GND"), IO(47), IO(48),
+};
+_Static_assert(sizeof(s_wifi6_right) / sizeof(s_wifi6_right[0]) == 20,
+               "s_wifi6_right: the column must hold exactly 20 pins");
+static const kvm_board_header_t s_headers[] = {
+    {.name = "", .rows = 20, .numbered = false, .left = s_wifi6_left,
+     .right = s_wifi6_right},
+};
+#define BOARD_HAS_HEADERS 1
+#define BOARD_NAME "Waveshare ESP32-P4-WIFI6"
+#define BOARD_ID_BASE "p4-wifi6"
+#define BOARD_VERIFIED true
 
 #elif CONFIG_KVM_BOARD_WAVESHARE_NANO
 /*

--- a/components/kvm_web/http_server.c
+++ b/components/kvm_web/http_server.c
@@ -263,7 +263,7 @@ static esp_err_t api_pins_get(httpd_req_t *req)
         pins_add_reserved(r, CONFIG_ESP_HOSTED_SDIO_D2_GPIO_RANGE_MIN, "WiFi co-processor D2");
         pins_add_reserved(r, CONFIG_ESP_HOSTED_SDIO_D3_GPIO_RANGE_MIN, "WiFi co-processor D3");
         pins_add_reserved(r, CONFIG_ESP_HOSTED_HOST_RESET_GPIO, "WiFi co-processor reset");
-#if CONFIG_KVM_BOARD_WAVESHARE_WIFI6_DEVKIT
+#if CONFIG_KVM_BOARD_WAVESHARE_WIFI6_DEVKIT || CONFIG_KVM_BOARD_WAVESHARE_WIFI6
         /* The schematic ties P4 GPIO 6 to the C6's IO2 through a 0R. esp-hosted
          * does not claim it, but offering it as free would let something an
          * owner plugs in fight the co-processor. */

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -154,6 +154,8 @@ menu "ESP-KVM"
                 bool "Waveshare ESP32-P4-WIFI6-POE-ETH"
             config KVM_BOARD_WAVESHARE_WIFI6_DEVKIT
                 bool "Waveshare ESP32-P4-WIFI6-DEV-KIT"
+            config KVM_BOARD_WAVESHARE_WIFI6
+                bool "Waveshare ESP32-P4-WIFI6"
             config KVM_BOARD_WAVESHARE_NANO
                 bool "Waveshare ESP32-P4-NANO"
             config KVM_BOARD_GUITION
@@ -235,9 +237,11 @@ menu "ESP-KVM"
         config KVM_MDNS_HOSTNAME
             string "mDNS hostname (device is <name>.local)"
             default "espkvm"
+            depends on KVM_ETH_ENABLE || KVM_WIFI
             help
                 DNS label only: letters, digits, hyphen. Advertised over mDNS and
-                sent as the DHCP client hostname when supported.
+                sent as the DHCP client hostname when supported. It is shared by
+                the Ethernet and WiFi transports.
 
                 Not tied to Ethernet: a board with no wired port still answers to
                 this name over WiFi, and it is also what the certificate and the


### PR DESCRIPTION
## Summary

Adds a first-class build target for the WiFi-only Waveshare ESP32-P4-WIFI6
(SKU 32020, P4 rev 1.3, 32 MB flash / 32 MB PSRAM).

- Adds the `p4-wifi6` CI/release-artifact target and its defaults overlay.
- Enables ESP-Hosted C6-over-SDIO WiFi, disables Ethernet, and starts fresh
  devices in the reachable setup-hotspot mode.
- Declares the board-specific microSD power GPIO, capture-reset omission,
  target-facing HID/UART details, board identity, and physical header layout.
- Reserves P4 GPIO6, which is tied to C6 IO2, and permits the mDNS hostname on
  WiFi-only builds.

## Hardware basis

The defaults were checked against Waveshare's published schematic and a
physical board: P4 rev 1.3, SDIO GPIO14-19 with C6 reset GPIO54, microSD power
GPIO45, capture I2C GPIO7/8, BOOT GPIO35, and no Ethernet PHY. The expansion
header layout was also checked on the physical board.

## Known limitation

This is intentionally a board-definition PR, not a claim that the current
ESP-Hosted WiFi data path is fully stable. With the official ESP-Hosted 3.0.6
C6 firmware and 40 MHz SDIO, boot/initial C6 handshake and AP association work
on the physical board, but a running data-plane stall remains reproducible
after some resets/reassociations. The accompanying Issue #27 follow-up includes
the small sanitized P4-side diagnostic log and details.

## Deliberately excluded

No C6 image, factory dump, diagnostic firmware, packet-mode/clock experiment,
Microlink change, TC358743 change, or dependency-lock change is included.

## Validation

- Parsed `.github/workflows/firmware.yml` and verified the `p4-wifi6` matrix
  entry locally.
- `git diff --check` passes.
- A local ESP-IDF build was not run: this checkout's lock requires IDF 6.2,
  while the available local 6.1 environment is incomplete. CI is the build
  authority for this upstream-base branch.
