### PR TITLE
fix: apply Waveshare SDIO pull-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to ESP-KVM are recorded here. The format follows
 semantic versioning while it is pre-1.0 (a new feature bumps the minor, a fix
 bumps the patch).
 
+## [Unreleased]
+
+### Fixed
+- **Enable Waveshare ESP32-P4-WIFI6 SDIO internal pull-ups before WiFi starts.**
+  The board's 51k external pull-ups can leave the C6 data-ready interrupt line
+  too weak; the existing board-specific setting now takes effect before
+  ESP-Hosted claims the SDIO controller.
+
 ## [0.41.0] - 2026-08-28
 
 ### Added

--- a/components/kvm_net/wifi.c
+++ b/components/kvm_net/wifi.c
@@ -501,6 +501,7 @@ esp_err_t kvm_wifi_init(void)
      * the point a WiFi mode needs it. esp-hosted 3.0 split the bring-up: esp_hosted_init
      * opens the transport, esp_hosted_connect_to_slave completes the handshake with the
      * C6 (older versions did both from esp_hosted_init). */
+    sdio_add_internal_pullups();
     int herr = esp_hosted_init();
     if (herr == 0) {
         herr = esp_hosted_connect_to_slave();


### PR DESCRIPTION
## Summary

- Invoke the existing Waveshare-only SDIO internal-pull-up helper before esp_hosted_init().
- The board-specific Kconfig option already defaults on for ESP32-P4-WIFI6, but without this call it never programmed CLK/CMD/D0-D3.

## Validation

Tested on a Waveshare ESP32-P4-WIFI6 (P4 rev 1.3, C6 esp-hosted 3.0.6), with 4-bit 40 MHz SDIO streaming:

- Three P4/C6 resets followed by explicit WLAN reassociation each restored DHCP and HTTP.
- Ten disconnect/reassociate cycles completed 30 HTTP page requests.
- A 100-request page burst transferred about 22 MB without an error.

This is limited to the single-client AP/DHCP/HTTP bench path. It does not claim multi-client, long-duration, or product-level recovery acceptance.